### PR TITLE
浏览模式下加载新页时，将页码更新到地址栏。（方便下次打开浏览器后直接定位到最新页码。）

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -83,6 +83,7 @@ const App = {
         jQuery.get(url, data => resolve(data))
       })
       if (response instanceof Array && response.length > 0) {
+        window.history.pushState("", "", location.pathname + "?" + this.params.toString())
         response.forEach(item => this.imageList.push(new Post(item)))
         const page = Number(this.params.get("page")) || 1
         this.params.set("page", page + 1)


### PR DESCRIPTION
由于在浏览模式下，地址栏不会更新页码。
关闭浏览器后再重新打开恢复上次页面后，无法恢复到上次的页码。
因此添加了一个更新页码的功能。

PS：实际这个页码是刚加载的新页码。
